### PR TITLE
feat: 예외처리를 위한 GlobalExceptionHandler 작성

### DIFF
--- a/src/main/java/jyang/deliverydotdot/controller/CommonController.java
+++ b/src/main/java/jyang/deliverydotdot/controller/CommonController.java
@@ -1,9 +1,12 @@
 package jyang.deliverydotdot.controller;
 
+import static org.springframework.http.HttpStatus.CREATED;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jyang.deliverydotdot.dto.UserJoinForm;
+import jyang.deliverydotdot.dto.response.SuccessResponse;
 import jyang.deliverydotdot.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,10 +25,13 @@ public class CommonController {
 
   @Operation(summary = "유저 회원가입", description = "유저 등록 폼으로 회원가입")
   @PostMapping("/users/join")
-  public ResponseEntity<?> userJoinProcess(
+  public ResponseEntity<SuccessResponse<?>> userJoinProcess(
       @RequestBody @Valid UserJoinForm joinForm
   ) {
     userService.registerUser(joinForm);
-    return ResponseEntity.ok().build();
+
+    return ResponseEntity.status(CREATED).body(
+        SuccessResponse.of("유저를 성공적으로 생성했습니다.")
+    );
   }
 }

--- a/src/main/java/jyang/deliverydotdot/dto/response/ErrorResponse.java
+++ b/src/main/java/jyang/deliverydotdot/dto/response/ErrorResponse.java
@@ -1,0 +1,36 @@
+package jyang.deliverydotdot.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.FieldError;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class ErrorResponse {
+
+  private final String code;
+  private final String message;
+
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  private final List<ValidationError> errors;
+
+  @Getter
+  @Builder
+  @RequiredArgsConstructor
+  public static class ValidationError {
+
+    private final String field;
+    private final String message;
+
+    public static ValidationError of(final FieldError fieldError) {
+      return ValidationError.builder()
+          .field(fieldError.getField())
+          .message(fieldError.getDefaultMessage())
+          .build();
+    }
+  }
+}

--- a/src/main/java/jyang/deliverydotdot/dto/response/SuccessResponse.java
+++ b/src/main/java/jyang/deliverydotdot/dto/response/SuccessResponse.java
@@ -1,0 +1,37 @@
+package jyang.deliverydotdot.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class SuccessResponse<T> {
+
+  private final String code;
+  private final String message;
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final T data;
+
+  public static <T> SuccessResponse<T> of(String message, T data) {
+    return SuccessResponse.<T>builder()
+        .code("SUCCESS")
+        .message(message)
+        .data(data)
+        .build();
+  }
+
+  public static <T> SuccessResponse<T> of(String message) {
+    return SuccessResponse.<T>builder()
+        .code("SUCCESS")
+        .message(message)
+        .build();
+  }
+
+  public static <T> SuccessResponse<T> of(T data) {
+    return SuccessResponse.of(null, data);
+  }
+}

--- a/src/main/java/jyang/deliverydotdot/exception/GlobalExceptionHandler.java
+++ b/src/main/java/jyang/deliverydotdot/exception/GlobalExceptionHandler.java
@@ -1,0 +1,109 @@
+package jyang.deliverydotdot.exception;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import jyang.deliverydotdot.dto.response.ErrorResponse;
+import jyang.deliverydotdot.dto.response.ErrorResponse.ValidationError;
+import jyang.deliverydotdot.type.ErrorCode;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  /**
+   * handleCustomException 처리 -> 커스텀 에러 처리
+   */
+  @ExceptionHandler(RestApiException.class)
+  public ResponseEntity<Object> handleCustomException(RestApiException e) {
+    ErrorCode errorCode = e.getErrorCode();
+    return handleExceptionInternal(errorCode);
+  }
+
+  /**
+   * IllegalArgumentException 처리 -> 적절하지 않은 파라미터
+   */
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<Object> handleIllegalArgument() {
+    ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
+    return handleExceptionInternal(errorCode);
+  }
+
+  /**
+   * DataIntegrityViolationException 처리 -> DB 제약 조건 위반
+   */
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  public ResponseEntity<Object> handleDataIntegrityViolation() {
+    ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
+    return handleExceptionInternal(errorCode);
+  }
+
+
+  /**
+   * MethodArgumentNotValidException 처리 -> @Valid로 걸러지는 예외
+   */
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+    ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
+    return handleExceptionInternal(e, errorCode);
+  }
+
+  /**
+   * IllegalStateException 처리 -> 예상치 못한 상태
+   */
+  @ExceptionHandler(IllegalStateException.class)
+  public ResponseEntity<Object> handleIllegalState() {
+    ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+    return handleExceptionInternal(errorCode);
+  }
+
+  /**
+   * 나머지 모든 예외 처리
+   */
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<Object> handleException() {
+    ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+    return ResponseEntity
+        .status(errorCode.getHttpStatus())
+        .body(makeErrorResponseBody(errorCode));
+  }
+
+  // ResponseEntity 생성
+  private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
+    return ResponseEntity
+        .status(errorCode.getHttpStatus())
+        .body(makeErrorResponseBody(errorCode));
+  }
+
+  private ResponseEntity<Object> handleExceptionInternal(BindException e, ErrorCode errorCode) {
+    return ResponseEntity.status(errorCode.getHttpStatus())
+        .body(makeErrorResponseBody(e, errorCode));
+  }
+
+  // ErrorResponseBody 생성
+  private ErrorResponse makeErrorResponseBody(ErrorCode errorCode) {
+    return ErrorResponse.builder()
+        .code(errorCode.name())
+        .message(errorCode.getDescription())
+        .build();
+  }
+
+  private ErrorResponse makeErrorResponseBody(BindException e, ErrorCode errorCode) {
+    List<ValidationError> validationErrorList = e.getBindingResult()
+        .getFieldErrors()
+        .stream()
+        .map(ErrorResponse.ValidationError::of)
+        .collect(Collectors.toList());
+
+    return ErrorResponse.builder()
+        .code(errorCode.name())
+        .message(errorCode.getDescription())
+        .errors(validationErrorList)
+        .build();
+  }
+
+}

--- a/src/main/java/jyang/deliverydotdot/exception/RestApiException.java
+++ b/src/main/java/jyang/deliverydotdot/exception/RestApiException.java
@@ -1,0 +1,12 @@
+package jyang.deliverydotdot.exception;
+
+import jyang.deliverydotdot.type.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RestApiException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+}

--- a/src/main/java/jyang/deliverydotdot/service/UserService.java
+++ b/src/main/java/jyang/deliverydotdot/service/UserService.java
@@ -1,9 +1,13 @@
 package jyang.deliverydotdot.service;
 
 import static jyang.deliverydotdot.type.AuthType.LOCAL;
+import static jyang.deliverydotdot.type.ErrorCode.ALREADY_REGISTERED_EMAIL;
+import static jyang.deliverydotdot.type.ErrorCode.ALREADY_REGISTERED_LOGIN_ID;
+import static jyang.deliverydotdot.type.ErrorCode.ALREADY_REGISTERED_PHONE;
 
 import jyang.deliverydotdot.domain.User;
 import jyang.deliverydotdot.dto.UserJoinForm;
+import jyang.deliverydotdot.exception.RestApiException;
 import jyang.deliverydotdot.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -40,13 +44,13 @@ public class UserService {
 
   private void validateRegisterUser(UserJoinForm userJoinForm) {
     if (userRepository.existsByLoginId(userJoinForm.getLoginId())) {
-      throw new RuntimeException("이미 등록된 로그인 id 입니다.");
+      throw new RestApiException(ALREADY_REGISTERED_LOGIN_ID);
     }
     if (userRepository.existsByEmail(userJoinForm.getEmail())) {
-      throw new RuntimeException("이미 등록된 이메일 입니다.");
+      throw new RestApiException(ALREADY_REGISTERED_EMAIL);
     }
     if (userRepository.existsByLoginId(userJoinForm.getPhone())) {
-      throw new RuntimeException("이미 등록된 휴대전화 번호 입니다.");
+      throw new RestApiException(ALREADY_REGISTERED_PHONE);
     }
   }
 

--- a/src/main/java/jyang/deliverydotdot/type/ErrorCode.java
+++ b/src/main/java/jyang/deliverydotdot/type/ErrorCode.java
@@ -1,0 +1,17 @@
+package jyang.deliverydotdot.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서부 오류가 발생했습니다."),
+  ALREADY_REGISTERED_LOGIN_ID(HttpStatus.BAD_REQUEST, "이미 등록된 로그인 id 입니다."),
+  ALREADY_REGISTERED_EMAIL(HttpStatus.BAD_REQUEST, "이미 등록된 이메일 입니다."),
+  ALREADY_REGISTERED_PHONE(HttpStatus.BAD_REQUEST, "이미 등록된 휴대전화 번호 입니다."),
+  INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
+  private final HttpStatus httpStatus;
+  private final String description;
+}

--- a/src/test/java/jyang/deliverydotdot/controller/CommonControllerTest.java
+++ b/src/test/java/jyang/deliverydotdot/controller/CommonControllerTest.java
@@ -3,12 +3,14 @@ package jyang.deliverydotdot.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jyang.deliverydotdot.config.SecurityConfig;
 import jyang.deliverydotdot.dto.UserJoinForm;
 import jyang.deliverydotdot.service.UserService;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,12 +59,39 @@ class CommonControllerTest {
     mockMvc.perform(post("/api/v1/common/users/join")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(user)))
-        .andExpect(status().isOk());
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.code").value("SUCCESS"))
+    ;
 
   }
 
   @Test
-  void 고객생성_실패_로그인아이디짧음() throws Exception {
+  void 고객생성_실패_로그인아이디_미입력() throws Exception {
+    //given
+    UserJoinForm user = UserJoinForm.builder()
+        .password("password123")
+        .name("김제로")
+        .email("abc@deliverydotdot.com")
+        .phone("010-1234-5678")
+        .address("서울시 강남구 테헤란로 231")
+        .build();
+
+    doNothing().when(userService).registerUser(any(UserJoinForm.class));
+
+    //when
+    //then
+    mockMvc.perform(post("/api/v1/common/users/join")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(user)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+        .andExpect(jsonPath("$.errors").isArray())
+        .andExpect(jsonPath("$.errors[0].field").value("loginId"))
+        .andExpect(jsonPath("$.errors[0].message").value("아이디를 입력해 주세요."));
+  }
+
+  @Test
+  void 고객생성_실패_로그인아이디_짧음() throws Exception {
     //given
     UserJoinForm user = UserJoinForm.builder()
         .loginId("loginId")
@@ -80,7 +109,166 @@ class CommonControllerTest {
     mockMvc.perform(post("/api/v1/common/users/join")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(user)))
-        .andExpect(status().isBadRequest());
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+        .andExpect(jsonPath("$.errors").isArray())
+        .andExpect(jsonPath("$.errors[0].field").value("loginId"))
+        .andExpect(jsonPath("$.errors[0].message").value("아이디는 8자 이상 20자 이하로 입력해 주세요."));
   }
 
+  @Test
+  void 고객생성_실패_로그인아이디_길이초과() throws Exception {
+    //given
+    UserJoinForm user = UserJoinForm.builder()
+        .loginId("loginId123123123123123")
+        .password("password123")
+        .name("김제로")
+        .email("abc@deliverydotdot.com")
+        .phone("010-1234-5678")
+        .address("서울시 강남구 테헤란로 231")
+        .build();
+
+    doNothing().when(userService).registerUser(any(UserJoinForm.class));
+
+    //when
+    //then
+    mockMvc.perform(post("/api/v1/common/users/join")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(user)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+        .andExpect(jsonPath("$.errors").isArray())
+        .andExpect(jsonPath("$.errors[0].field").value("loginId"))
+        .andExpect(jsonPath("$.errors[0].message").value("아이디는 8자 이상 20자 이하로 입력해 주세요."));
+  }
+
+  @Test
+  void 고객생성_실패_이메일_미입력() throws Exception {
+    //given
+    UserJoinForm user = UserJoinForm.builder()
+        .loginId("loginId123")
+        .password("password123")
+        .name("김제로")
+        .phone("010-1234-5678")
+        .address("서울시 강남구 테헤란로 231")
+        .build();
+
+    doNothing().when(userService).registerUser(any(UserJoinForm.class));
+
+    //when
+    //then
+    mockMvc.perform(post("/api/v1/common/users/join")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(user)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+        .andExpect(jsonPath("$.errors").isArray())
+        .andExpect(jsonPath("$.errors[0].field").value("email"))
+        .andExpect(jsonPath("$.errors[0].message").value("이메일을 입력해 주세요."));
+  }
+
+  @Test
+  void 고객생성_실패_이메일_유효하지않은이메일() throws Exception {
+    //given
+    UserJoinForm user = UserJoinForm.builder()
+        .loginId("loginId123")
+        .password("password123")
+        .name("김제로")
+        .email("invalidEmail")
+        .phone("010-1234-5678")
+        .address("서울시 강남구 테헤란로 231")
+        .build();
+
+    doNothing().when(userService).registerUser(any(UserJoinForm.class));
+
+    //when
+    //then
+    mockMvc.perform(post("/api/v1/common/users/join")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(user)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+        .andExpect(jsonPath("$.errors").isArray())
+        .andExpect(jsonPath("$.errors[0].field").value("email"))
+        .andExpect(jsonPath("$.errors[0].message").value("유효하지 않은 이메일 형식 입니다."));
+  }
+
+  @Test
+  void 고객생성_실패_휴대전화번호_미입력() throws Exception {
+    //given
+    UserJoinForm user = UserJoinForm.builder()
+        .loginId("loginId123")
+        .password("password123")
+        .name("김제로")
+        .email("abc@deliverydotdot.com")
+        .address("서울시 강남구 테헤란로 231")
+        .build();
+
+    doNothing().when(userService).registerUser(any(UserJoinForm.class));
+
+    //when
+    //then
+    mockMvc.perform(post("/api/v1/common/users/join")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(user)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+        .andExpect(jsonPath("$.errors").isArray())
+        .andExpect(jsonPath("$.errors[0].field").value("phone"))
+        .andExpect(jsonPath("$.errors[0].message").value("휴대전화 번호를 입력해 주세요."));
+  }
+
+  @Test
+  void 고객생성_실패_휴대전화번호_유효하지않은번호() throws Exception {
+    //given
+    UserJoinForm user = UserJoinForm.builder()
+        .loginId("loginId123")
+        .password("password123")
+        .name("김제로")
+        .email("abc@deliverydotdot.com")
+        .phone("1234-12345-12345")
+        .address("서울시 강남구 테헤란로 231")
+        .build();
+
+    doNothing().when(userService).registerUser(any(UserJoinForm.class));
+
+    //when
+    //then
+    mockMvc.perform(post("/api/v1/common/users/join")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(user)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+        .andExpect(jsonPath("$.errors").isArray())
+        .andExpect(jsonPath("$.errors[0].field").value("phone"))
+        .andExpect(jsonPath("$.errors[0].message").value("유효하지 않은 휴대전화 번호 입니다."));
+  }
+
+  @Test
+  void 고객생성_실패_전체미입력() throws Exception {
+    //given
+    UserJoinForm user = UserJoinForm.builder()
+        .build();
+
+    doNothing().when(userService).registerUser(any(UserJoinForm.class));
+
+    //when
+    //then
+    mockMvc.perform(post("/api/v1/common/users/join")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(user)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+        .andExpect(jsonPath("$.errors").isArray())
+        .andExpect(jsonPath("$.errors[*].field").value(Matchers.containsInAnyOrder(
+            "loginId", "password", "name", "email", "phone", "address")))
+        .andExpect(jsonPath("$.errors[*].message").value(Matchers.containsInAnyOrder(
+            "아이디를 입력해 주세요.",
+            "비밀번호를 입력해 주세요.",
+            "이름을 입력해 주세요.",
+            "이메일을 입력해 주세요.",
+            "휴대전화 번호를 입력해 주세요.",
+            "주소를 입력해 주세요."
+        )));
+  }
 }

--- a/src/test/java/jyang/deliverydotdot/service/UserServiceTest.java
+++ b/src/test/java/jyang/deliverydotdot/service/UserServiceTest.java
@@ -1,5 +1,8 @@
 package jyang.deliverydotdot.service;
 
+import static jyang.deliverydotdot.type.ErrorCode.ALREADY_REGISTERED_EMAIL;
+import static jyang.deliverydotdot.type.ErrorCode.ALREADY_REGISTERED_LOGIN_ID;
+import static jyang.deliverydotdot.type.ErrorCode.ALREADY_REGISTERED_PHONE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
@@ -8,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import jyang.deliverydotdot.domain.User;
 import jyang.deliverydotdot.dto.UserJoinForm;
+import jyang.deliverydotdot.exception.RestApiException;
 import jyang.deliverydotdot.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,30 +56,27 @@ public class UserServiceTest {
   @Test
   void 유저생성_실패_이미등록된아이디() {
     when(userRepository.existsByLoginId("userLoginId")).thenReturn(true);
-    Exception exception = assertThrows(RuntimeException.class, () -> {
-      userService.registerUser(validUserJoinForm);
-    });
+    RestApiException exception = assertThrows(RestApiException.class,
+        () -> userService.registerUser(validUserJoinForm));
 
-    assertEquals("이미 등록된 로그인 id 입니다.", exception.getMessage());
+    assertEquals(ALREADY_REGISTERED_LOGIN_ID, exception.getErrorCode());
   }
 
   @Test
   void 유저생성_실패_이미등록된이메일() {
     when(userRepository.existsByEmail("user@example.com")).thenReturn(true);
-    Exception exception = assertThrows(RuntimeException.class, () -> {
-      userService.registerUser(validUserJoinForm);
-    });
+    RestApiException exception = assertThrows(RestApiException.class,
+        () -> userService.registerUser(validUserJoinForm));
 
-    assertEquals("이미 등록된 이메일 입니다.", exception.getMessage());
+    assertEquals(ALREADY_REGISTERED_EMAIL, exception.getErrorCode());
   }
 
   @Test
   void 유저생성_실패_이미등록된휴대전화() {
     when(userRepository.existsByLoginId("010-1234-5678")).thenReturn(true);
-    Exception exception = assertThrows(RuntimeException.class, () -> {
-      userService.registerUser(validUserJoinForm);
-    });
+    RestApiException exception = assertThrows(RestApiException.class,
+        () -> userService.registerUser(validUserJoinForm));
 
-    assertEquals("이미 등록된 휴대전화 번호 입니다.", exception.getMessage());
+    assertEquals(ALREADY_REGISTERED_PHONE, exception.getErrorCode());
   }
 }


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 기존 코드에는 예외를 전역적으로 처리하지 않고, 각 예외 상황에 대해 RuntimeException을 발생시키기만 하였음.

**TO-BE**
- 예외를 전역적으로 처리하는 GlobalExceptionHandler를 추가하여 모든 예외에 대해 공통적인 포맷으로 예외를 처리하도록 수정
- 적절한 에러 코드와 응답 객체를 생성
- 기존 테스트 코드를 수정 및 부족한 테스트 코드 추가 작성

### 테스트

- [x] 테스트 코드
- [x] API 테스트 