### PR TITLE
feat: 기본 배송지 저장 기능 추가, JWT 발급 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,12 +23,15 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
     implementation 'org.hibernate:hibernate-spatial:6.5.0.Final'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    implementation 'org.hibernate:hibernate-spatial:6.5.0.Final'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/jyang/deliverydotdot/authentication/JwtAuthenticationFilter.java
+++ b/src/main/java/jyang/deliverydotdot/authentication/JwtAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package jyang.deliverydotdot.authentication;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import jyang.deliverydotdot.dto.CommonUserDetails;
+import jyang.deliverydotdot.type.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    // 헤더에서 토큰 추출
+    String token = parseBearerToken(request);
+
+    // 토큰이 유효할 때
+    if (token != null && !jwtTokenProvider.isExpired(token)) {
+      String username = jwtTokenProvider.getUsername(token);
+      String role = jwtTokenProvider.getRole(token);
+
+      // 사용자 정보를 이용해 Authentication 객체 생성
+      CommonUserDetails user =
+          new CommonUserDetails(username, "", UserRole.valueOf(role.toUpperCase()));
+
+      Authentication authentication =
+          new UsernamePasswordAuthenticationToken(user, token, user.getAuthorities());
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    // 다음 필터로 이동
+    filterChain.doFilter(request, response);
+  }
+
+  // 헤더에서 Bearer 토큰 추출
+  private String parseBearerToken(HttpServletRequest request) {
+    return Optional.ofNullable(request.getHeader(HttpHeaders.AUTHORIZATION))
+        .filter(token -> token.substring(0, 7).equalsIgnoreCase("Bearer "))
+        .map(token -> token.substring(7))
+        .orElse(null);
+  }
+}

--- a/src/main/java/jyang/deliverydotdot/authentication/JwtTokenProvider.java
+++ b/src/main/java/jyang/deliverydotdot/authentication/JwtTokenProvider.java
@@ -1,0 +1,54 @@
+package jyang.deliverydotdot.authentication;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+  private final SecretKey secretKey;
+  private final long expiration;
+
+  public JwtTokenProvider(
+      @Value("${spring.jwt.secret}") String secretKey,
+      @Value("${spring.jwt.expiration}") long expiration
+  ) {
+    this.secretKey = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8),
+        Jwts.SIG.HS256.key().build().getAlgorithm());
+    this.expiration = expiration;
+  }
+
+  public String createToken(String username, String role) {
+    long now = System.currentTimeMillis();
+    return Jwts.builder()
+        .claim("username", username)
+        .claim("role", role)
+        .issuedAt(new Date(now))
+        .expiration(new Date(now + expiration))
+        .signWith(secretKey)
+        .compact();
+  }
+
+  public Claims getClaims(String token) {
+    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload();
+  }
+
+  public String getUsername(String token) {
+    return getClaims(token).get("username", String.class);
+  }
+
+  public String getRole(String token) {
+    return getClaims(token).get("role", String.class);
+  }
+
+  public Boolean isExpired(String token) {
+    return getClaims(token).getExpiration().before(new Date());
+  }
+
+}

--- a/src/main/java/jyang/deliverydotdot/authentication/UserLoginFilter.java
+++ b/src/main/java/jyang/deliverydotdot/authentication/UserLoginFilter.java
@@ -1,0 +1,72 @@
+package jyang.deliverydotdot.authentication;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collection;
+import jyang.deliverydotdot.dto.CommonUserDetails;
+import jyang.deliverydotdot.type.UserRole;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+public class UserLoginFilter extends UsernamePasswordAuthenticationFilter {
+
+  private final AuthenticationManager authenticationManager;
+
+  private final JwtTokenProvider jwtTokenProvider;
+
+  public UserLoginFilter(AuthenticationManager authenticationManager,
+      JwtTokenProvider jwtTokenProvider) {
+
+    setFilterProcessesUrl("/api/v1/users/auth/login");
+    this.authenticationManager = authenticationManager;
+    this.jwtTokenProvider = jwtTokenProvider;
+  }
+
+  // 로그인 시도
+  @Override
+  public Authentication attemptAuthentication(HttpServletRequest request,
+      HttpServletResponse response) throws AuthenticationException {
+    String identifier = UserRole.ROLE_USER.name() + ":" + obtainUsername(request);
+    String password = obtainPassword(request);
+
+    UsernamePasswordAuthenticationToken authenticationToken =
+        new UsernamePasswordAuthenticationToken(identifier, password);
+
+    return authenticationManager.authenticate(authenticationToken);
+  }
+
+  // 로그인 성공
+  @Override
+  protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+      FilterChain chain, Authentication authResult) throws IOException, ServletException {
+
+    CommonUserDetails user = (CommonUserDetails) authResult.getPrincipal();
+
+    String username = user.getUsername();
+
+    Collection<? extends GrantedAuthority> authorities = authResult.getAuthorities();
+    GrantedAuthority auth = authorities.iterator().next();
+
+    String role = auth.getAuthority();
+
+    String token = jwtTokenProvider.createToken(username, role);
+
+    response.addHeader("Authorization", "Bearer " + token);
+  }
+
+  // 로그인 실패
+  @Override
+  protected void unsuccessfulAuthentication(HttpServletRequest request,
+      HttpServletResponse response, AuthenticationException failed)
+      throws IOException, ServletException {
+
+    response.setStatus(401);
+  }
+}

--- a/src/main/java/jyang/deliverydotdot/config/AppConfig.java
+++ b/src/main/java/jyang/deliverydotdot/config/AppConfig.java
@@ -1,0 +1,20 @@
+package jyang.deliverydotdot.config;
+
+import org.locationtech.jts.geom.GeometryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+
+  @Bean
+  public GeometryFactory geometryFactory() {
+    return new GeometryFactory();
+  }
+}

--- a/src/main/java/jyang/deliverydotdot/config/CorsMvcConfig.java
+++ b/src/main/java/jyang/deliverydotdot/config/CorsMvcConfig.java
@@ -10,7 +10,7 @@ public class CorsMvcConfig implements WebMvcConfigurer {
   @Override
   public void addCorsMappings(CorsRegistry registry) {
     registry.addMapping("/**")
-        .allowedOrigins("*")
+        .allowedOrigins("/**") // TODO: 추후 수정 필요
         .allowedMethods("GET", "POST", "PUT", "DELETE")
         .allowedHeaders("Authorization", "Content-Type")
         .exposedHeaders("Authorization")

--- a/src/main/java/jyang/deliverydotdot/config/CorsMvcConfig.java
+++ b/src/main/java/jyang/deliverydotdot/config/CorsMvcConfig.java
@@ -1,0 +1,21 @@
+package jyang.deliverydotdot.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsMvcConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/**")
+        .allowedOrigins("*")
+        .allowedMethods("GET", "POST", "PUT", "DELETE")
+        .allowedHeaders("Authorization", "Content-Type")
+        .exposedHeaders("Authorization")
+        .allowCredentials(true)
+        .maxAge(3600);
+
+  }
+}

--- a/src/main/java/jyang/deliverydotdot/config/SecurityConfig.java
+++ b/src/main/java/jyang/deliverydotdot/config/SecurityConfig.java
@@ -17,7 +17,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
-@EnableWebSecurity(debug = true)
+@EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/jyang/deliverydotdot/config/SecurityConfig.java
+++ b/src/main/java/jyang/deliverydotdot/config/SecurityConfig.java
@@ -1,18 +1,37 @@
 package jyang.deliverydotdot.config;
 
+import jyang.deliverydotdot.authentication.JwtAuthenticationFilter;
+import jyang.deliverydotdot.authentication.JwtTokenProvider;
+import jyang.deliverydotdot.authentication.UserLoginFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
-@EnableWebSecurity
+@EnableWebSecurity(debug = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final AuthenticationConfiguration authenticationConfiguration;
+
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @Bean
+  public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
+      throws Exception {
+    return configuration.getAuthenticationManager();
+  }
 
   @Bean
   public BCryptPasswordEncoder passwordEncoder() {
@@ -20,20 +39,85 @@ public class SecurityConfig {
   }
 
   @Bean
-  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+  public SecurityFilterChain commonFilterChain(HttpSecurity http) throws Exception {
+    configureCommonSecuritySettings(http); // 공통 보안 설정 적용
+
     http
-        .csrf(AbstractHttpConfigurer::disable)
-        .cors(AbstractHttpConfigurer::disable)
+        .securityMatchers(auth -> auth.requestMatchers("/api/v1/common/**"))
         .authorizeHttpRequests(request -> request
-                .requestMatchers("/swagger-ui/*", "/v3/**").permitAll()
-                .requestMatchers("/api/v1/common/*").permitAll()
-                .requestMatchers("/api/v1/common/*/*").permitAll()
-//            .requestMatchers("/api/v1/users").hasRole("USER")
-//            .requestMatchers("/api/v1/partners").hasRole("PARTNER")
-//            .requestMatchers("/api/v1/riders").hasRole("RIDER")
-                .anyRequest().authenticated()
+            .requestMatchers("/swagger-ui/*", "/v3/**").permitAll() // swagger-ui 접근 허용
+            .requestMatchers("/api/v1/common/*/**").permitAll()
+            .anyRequest().authenticated()
+
         );
     return http.build();
   }
 
+  /**
+   * 사용자 관련 API 보안 설정
+   */
+  @Bean
+  public SecurityFilterChain userSecurityFilterChain(HttpSecurity http) throws Exception {
+    configureCommonSecuritySettings(http); // 공통 보안 설정 적용
+
+    http
+        .securityMatchers(auth -> auth.requestMatchers("/api/v1/users/**"))
+
+        .addFilterBefore(jwtAuthenticationFilter, UserLoginFilter.class) // jwt 검증 필터 추가
+        .addFilterBefore(new UserLoginFilter(authenticationManager(authenticationConfiguration),
+            jwtTokenProvider), UsernamePasswordAuthenticationFilter.class) // 로그인 필터 추가
+
+        .authorizeHttpRequests(request -> request
+            .requestMatchers("/api/v1/users/auth/**").permitAll() // 로그인, 회원가입 허용
+            .requestMatchers("/api/v1/users/my/**").hasRole("USER")
+            .anyRequest().authenticated()
+        );
+    return http.build();
+  }
+
+  /**
+   * 파트너 관련 API 보안 설정
+   */
+  @Bean
+  public SecurityFilterChain partnerSecurityFilterChain(HttpSecurity http) throws Exception {
+    configureCommonSecuritySettings(http); // 공통 보안 설정 적용
+
+    http
+        .securityMatchers(auth -> auth.requestMatchers("/api/v1/partners/**"))
+        .authorizeHttpRequests(request -> request
+            .requestMatchers("/api/v1/partners/auth/**").permitAll()
+            .anyRequest().authenticated()
+
+        );
+    return http.build();
+  }
+
+  /**
+   * 라이더 관련 API 보안 설정
+   */
+  @Bean
+  public SecurityFilterChain riderSecurityFilterChain(HttpSecurity http) throws Exception {
+    configureCommonSecuritySettings(http); // 공통 보안 설정 적용
+
+    http
+        .securityMatchers(auth -> auth.requestMatchers("/api/v1/riders/**"))
+        .authorizeHttpRequests(request -> request
+            .requestMatchers("/api/v1/riders/auth/**").permitAll()
+            .anyRequest().authenticated()
+        );
+    return http.build();
+  }
+
+  // 공통 보안 설정
+  private void configureCommonSecuritySettings(HttpSecurity http) throws Exception {
+    http
+        .csrf(AbstractHttpConfigurer::disable) // csrf 비활성화
+        .cors(AbstractHttpConfigurer::disable) // cors 비활성화
+        .formLogin(AbstractHttpConfigurer::disable) // form 로그인 방식 비활성화
+        .httpBasic(AbstractHttpConfigurer::disable) // http basic 인증 비활성화
+        .sessionManagement(
+            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 비활성화
+    ;
+
+  }
 }

--- a/src/main/java/jyang/deliverydotdot/config/SwaggerConfig.java
+++ b/src/main/java/jyang/deliverydotdot/config/SwaggerConfig.java
@@ -1,12 +1,17 @@
 package jyang.deliverydotdot.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
+
+  private static final String SECURITY_SCHEMA_NAME = "authorization";
 
   @Bean
   public OpenAPI api() {
@@ -15,6 +20,15 @@ public class SwaggerConfig {
             new Info()
                 .title("DeliveryDotDot")
                 .description("배달 어플리케이션의 백엔드 API 입니다.")
-        );
+        )
+        .components(new Components()
+            .addSecuritySchemes(SECURITY_SCHEMA_NAME, new SecurityScheme()
+                .name(SECURITY_SCHEMA_NAME)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")))
+        .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEMA_NAME))
+        
+        ;
   }
 }

--- a/src/main/java/jyang/deliverydotdot/controller/CommonController.java
+++ b/src/main/java/jyang/deliverydotdot/controller/CommonController.java
@@ -1,17 +1,7 @@
 package jyang.deliverydotdot.controller;
 
-import static org.springframework.http.HttpStatus.CREATED;
-
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import jyang.deliverydotdot.dto.UserJoinForm;
-import jyang.deliverydotdot.dto.response.SuccessResponse;
-import jyang.deliverydotdot.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,17 +11,4 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Common API", description = "공통 API")
 public class CommonController {
 
-  private final UserService userService;
-
-  @Operation(summary = "유저 회원가입", description = "유저 등록 폼으로 회원가입")
-  @PostMapping("/users/join")
-  public ResponseEntity<SuccessResponse<?>> userJoinProcess(
-      @RequestBody @Valid UserJoinForm joinForm
-  ) {
-    userService.registerUser(joinForm);
-
-    return ResponseEntity.status(CREATED).body(
-        SuccessResponse.of("유저를 성공적으로 생성했습니다.")
-    );
-  }
 }

--- a/src/main/java/jyang/deliverydotdot/controller/UserController.java
+++ b/src/main/java/jyang/deliverydotdot/controller/UserController.java
@@ -1,7 +1,21 @@
 package jyang.deliverydotdot.controller;
 
+import static org.springframework.http.HttpStatus.CREATED;
+
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jyang.deliverydotdot.dto.UserJoinForm;
+import jyang.deliverydotdot.dto.response.SuccessResponse;
+import jyang.deliverydotdot.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,4 +25,33 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "User API", description = "유저 전용 API")
 public class UserController {
 
+  private final UserService userService;
+
+  @GetMapping("/my")
+  public String my() {
+    String username = SecurityContextHolder
+        .getContext()
+        .getAuthentication()
+        .getName();
+
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    GrantedAuthority auth = authentication.getAuthorities().iterator().next();
+
+    String role = auth.getAuthority();
+
+    return "Main Controller : " + username + " " + role;
+  }
+
+  @Operation(summary = "유저 회원가입", description = "유저 등록 폼으로 회원가입")
+  @PostMapping("/auth/join")
+  public ResponseEntity<SuccessResponse<?>> userJoinProcess(
+      @RequestBody @Valid UserJoinForm joinForm
+  ) {
+    userService.registerUser(joinForm);
+
+    return ResponseEntity.status(CREATED).body(
+        SuccessResponse.of("유저를 성공적으로 생성했습니다.")
+    );
+  }
 }

--- a/src/main/java/jyang/deliverydotdot/domain/User.java
+++ b/src/main/java/jyang/deliverydotdot/domain/User.java
@@ -53,5 +53,4 @@ public class User extends BaseEntity {
   private String provider;
 
   private String providerId;
-
 }

--- a/src/main/java/jyang/deliverydotdot/domain/UserDeliveryAddress.java
+++ b/src/main/java/jyang/deliverydotdot/domain/UserDeliveryAddress.java
@@ -1,0 +1,44 @@
+package jyang.deliverydotdot.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserDeliveryAddress {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User user;
+
+  @Column(nullable = false)
+  private String addressName;
+
+  @Column(nullable = false)
+  private String address;
+
+  @Column(nullable = false, columnDefinition = "POINT")
+  private Point coordinates;
+
+  @Column(nullable = false)
+  private boolean isDefaultAddress;
+
+}

--- a/src/main/java/jyang/deliverydotdot/dto/CommonUserDetails.java
+++ b/src/main/java/jyang/deliverydotdot/dto/CommonUserDetails.java
@@ -1,0 +1,72 @@
+package jyang.deliverydotdot.dto;
+
+import static jyang.deliverydotdot.type.UserRole.ROLE_USER;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import jyang.deliverydotdot.domain.User;
+import jyang.deliverydotdot.type.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CommonUserDetails implements UserDetails {
+
+  private final String username;
+  private final String password;
+  private final UserRole userRole;
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+
+    Collection<GrantedAuthority> collection = new ArrayList<>();
+    collection.add(userRole::name);
+
+    return collection;
+  }
+
+  @Override
+  public String getPassword() {
+    return this.password;
+  }
+
+  @Override
+  public String getUsername() {
+    return this.username;
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+
+  public static CommonUserDetails fromUser(User user) {
+    return CommonUserDetails.builder()
+        .username(user.getLoginId())
+        .password(user.getPassword())
+        .userRole(ROLE_USER)
+        .build();
+  }
+  
+}

--- a/src/main/java/jyang/deliverydotdot/dto/location/KakaoGeoResponse.java
+++ b/src/main/java/jyang/deliverydotdot/dto/location/KakaoGeoResponse.java
@@ -1,0 +1,32 @@
+package jyang.deliverydotdot.dto.location;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KakaoGeoResponse {
+
+  private List<Document> documents;
+
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Document {
+
+    private String address_name;
+    private String x;
+    private String y;
+
+  }
+
+}

--- a/src/main/java/jyang/deliverydotdot/dto/location/KakaoGeoResponse.java
+++ b/src/main/java/jyang/deliverydotdot/dto/location/KakaoGeoResponse.java
@@ -1,5 +1,6 @@
 package jyang.deliverydotdot.dto.location;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,7 +24,8 @@ public class KakaoGeoResponse {
   @AllArgsConstructor
   public static class Document {
 
-    private String address_name;
+    @JsonProperty("address_name")
+    private String addressName;
     private String x;
     private String y;
 

--- a/src/main/java/jyang/deliverydotdot/exception/GlobalExceptionHandler.java
+++ b/src/main/java/jyang/deliverydotdot/exception/GlobalExceptionHandler.java
@@ -9,8 +9,7 @@ import java.util.stream.Collectors;
 import jyang.deliverydotdot.dto.response.ErrorResponse;
 import jyang.deliverydotdot.dto.response.ErrorResponse.ValidationError;
 import jyang.deliverydotdot.type.ErrorCode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -23,16 +22,15 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
-
-  private final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
   /**
    * handleCustomException 처리 -> 커스텀 에러 처리
    */
   @ExceptionHandler(RestApiException.class)
   public ResponseEntity<Object> handleCustomException(RestApiException e) {
-    logger.error("RestApiException occurred", e);
+    log.error("RestApiException occurred", e);
     ErrorCode errorCode = e.getErrorCode();
     return handleExceptionInternal(errorCode);
   }
@@ -42,7 +40,7 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(IllegalArgumentException.class)
   public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException e) {
-    logger.error("IllegalArgumentException occurred", e);
+    log.error("IllegalArgumentException occurred", e);
     return handleExceptionInternal(INVALID_REQUEST);
   }
 
@@ -51,7 +49,7 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(DataIntegrityViolationException.class)
   public ResponseEntity<Object> handleDataIntegrityViolation(DataIntegrityViolationException e) {
-    logger.error("DataIntegrityViolationException occurred", e);
+    log.error("DataIntegrityViolationException occurred", e);
     return handleExceptionInternal(INVALID_REQUEST);
   }
 
@@ -61,7 +59,7 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
-    logger.error("MethodArgumentNotValidException occurred", e);
+    log.error("MethodArgumentNotValidException occurred", e);
     return handleExceptionInternal(e, INVALID_REQUEST);
   }
 
@@ -70,7 +68,7 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(IllegalStateException.class)
   public ResponseEntity<Object> handleIllegalState(IllegalArgumentException e) {
-    logger.error("IllegalStateException occurred", e);
+    log.error("IllegalStateException occurred", e);
     return handleExceptionInternal(INTERNAL_SERVER_ERROR);
   }
 
@@ -79,7 +77,7 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(HttpClientErrorException.class)
   public ResponseEntity<Object> handleHttpClientError(HttpClientErrorException e) {
-    logger.error("HttpClientErrorException occurred", e);
+    log.error("HttpClientErrorException occurred", e);
     return handleExceptionInternal(INVALID_REQUEST);
   }
 
@@ -88,7 +86,7 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(HttpServerErrorException.class)
   public ResponseEntity<Object> handleHttpServerError(HttpServerErrorException e) {
-    logger.error("HttpServerErrorException occurred", e);
+    log.error("HttpServerErrorException occurred", e);
     return handleExceptionInternal(EXTERNAL_API_ERROR);
   }
 
@@ -97,7 +95,7 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(HttpMessageNotReadableException.class)
   public ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
-    logger.error("HttpMessageNotReadableException occurred", e);
+    log.error("HttpMessageNotReadableException occurred", e);
     return handleExceptionInternal(ErrorCode.UNPROCESSABLE_ENTITY);
   }
 
@@ -106,7 +104,7 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(UsernameNotFoundException.class)
   public ResponseEntity<Object> handleUsernameNotFound(UsernameNotFoundException e) {
-    logger.error("UsernameNotFoundException occurred", e);
+    log.error("UsernameNotFoundException occurred", e);
     return handleExceptionInternal(INVALID_REQUEST);
   }
 
@@ -115,7 +113,7 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(Exception.class)
   public ResponseEntity<Object> handleException(Exception e) {
-    logger.error("Unhandled exception occurred", e);
+    log.error("Unhandled exception occurred", e);
     ErrorCode errorCode = INTERNAL_SERVER_ERROR;
     return ResponseEntity
         .status(errorCode.getHttpStatus())

--- a/src/main/java/jyang/deliverydotdot/exception/GlobalExceptionHandler.java
+++ b/src/main/java/jyang/deliverydotdot/exception/GlobalExceptionHandler.java
@@ -9,9 +9,12 @@ import java.util.stream.Collectors;
 import jyang.deliverydotdot.dto.response.ErrorResponse;
 import jyang.deliverydotdot.dto.response.ErrorResponse.ValidationError;
 import jyang.deliverydotdot.type.ErrorCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -22,11 +25,14 @@ import org.springframework.web.client.HttpServerErrorException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+  private final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
   /**
    * handleCustomException 처리 -> 커스텀 에러 처리
    */
   @ExceptionHandler(RestApiException.class)
   public ResponseEntity<Object> handleCustomException(RestApiException e) {
+    logger.error("RestApiException occurred", e);
     ErrorCode errorCode = e.getErrorCode();
     return handleExceptionInternal(errorCode);
   }
@@ -35,7 +41,8 @@ public class GlobalExceptionHandler {
    * IllegalArgumentException 처리 -> 적절하지 않은 파라미터
    */
   @ExceptionHandler(IllegalArgumentException.class)
-  public ResponseEntity<Object> handleIllegalArgument() {
+  public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException e) {
+    logger.error("IllegalArgumentException occurred", e);
     return handleExceptionInternal(INVALID_REQUEST);
   }
 
@@ -43,7 +50,8 @@ public class GlobalExceptionHandler {
    * DataIntegrityViolationException 처리 -> DB 제약 조건 위반
    */
   @ExceptionHandler(DataIntegrityViolationException.class)
-  public ResponseEntity<Object> handleDataIntegrityViolation() {
+  public ResponseEntity<Object> handleDataIntegrityViolation(DataIntegrityViolationException e) {
+    logger.error("DataIntegrityViolationException occurred", e);
     return handleExceptionInternal(INVALID_REQUEST);
   }
 
@@ -53,6 +61,7 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+    logger.error("MethodArgumentNotValidException occurred", e);
     return handleExceptionInternal(e, INVALID_REQUEST);
   }
 
@@ -60,7 +69,8 @@ public class GlobalExceptionHandler {
    * IllegalStateException 처리 -> 예상치 못한 상태
    */
   @ExceptionHandler(IllegalStateException.class)
-  public ResponseEntity<Object> handleIllegalState() {
+  public ResponseEntity<Object> handleIllegalState(IllegalArgumentException e) {
+    logger.error("IllegalStateException occurred", e);
     return handleExceptionInternal(INTERNAL_SERVER_ERROR);
   }
 
@@ -69,6 +79,7 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(HttpClientErrorException.class)
   public ResponseEntity<Object> handleHttpClientError(HttpClientErrorException e) {
+    logger.error("HttpClientErrorException occurred", e);
     return handleExceptionInternal(INVALID_REQUEST);
   }
 
@@ -77,6 +88,7 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(HttpServerErrorException.class)
   public ResponseEntity<Object> handleHttpServerError(HttpServerErrorException e) {
+    logger.error("HttpServerErrorException occurred", e);
     return handleExceptionInternal(EXTERNAL_API_ERROR);
   }
 
@@ -85,14 +97,25 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(HttpMessageNotReadableException.class)
   public ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+    logger.error("HttpMessageNotReadableException occurred", e);
     return handleExceptionInternal(ErrorCode.UNPROCESSABLE_ENTITY);
+  }
+
+  /**
+   * UsernameNotFoundException 처리 -> 유저를 찾을 수 없음
+   */
+  @ExceptionHandler(UsernameNotFoundException.class)
+  public ResponseEntity<Object> handleUsernameNotFound(UsernameNotFoundException e) {
+    logger.error("UsernameNotFoundException occurred", e);
+    return handleExceptionInternal(INVALID_REQUEST);
   }
 
   /**
    * 나머지 모든 예외 처리
    */
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<Object> handleException() {
+  public ResponseEntity<Object> handleException(Exception e) {
+    logger.error("Unhandled exception occurred", e);
     ErrorCode errorCode = INTERNAL_SERVER_ERROR;
     return ResponseEntity
         .status(errorCode.getHttpStatus())

--- a/src/main/java/jyang/deliverydotdot/repository/UserDeliveryAddressRepository.java
+++ b/src/main/java/jyang/deliverydotdot/repository/UserDeliveryAddressRepository.java
@@ -1,0 +1,10 @@
+package jyang.deliverydotdot.repository;
+
+import jyang.deliverydotdot.domain.UserDeliveryAddress;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserDeliveryAddressRepository extends JpaRepository<UserDeliveryAddress, Long> {
+  
+}

--- a/src/main/java/jyang/deliverydotdot/repository/UserRepository.java
+++ b/src/main/java/jyang/deliverydotdot/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package jyang.deliverydotdot.repository;
 
+import java.util.Optional;
 import jyang.deliverydotdot.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -13,4 +14,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   boolean existsByPhone(String phone);
 
+  Optional<User> findByLoginId(String loginId);
 }

--- a/src/main/java/jyang/deliverydotdot/service/CommonUserDetailsService.java
+++ b/src/main/java/jyang/deliverydotdot/service/CommonUserDetailsService.java
@@ -1,0 +1,52 @@
+package jyang.deliverydotdot.service;
+
+import jyang.deliverydotdot.dto.CommonUserDetails;
+import jyang.deliverydotdot.repository.UserRepository;
+import jyang.deliverydotdot.type.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommonUserDetailsService implements UserDetailsService {
+
+  private final UserRepository userRepository;
+
+  private final Logger logger = LoggerFactory.getLogger(UserRole.class);
+
+  @Override
+  public UserDetails loadUserByUsername(String identifier) throws UsernameNotFoundException {
+    if (!identifier.contains(":")) {
+      logger.error("Invalid identifier format: {}", identifier);
+      throw new UsernameNotFoundException("Identifier must be in the format 'UserType:loginId'");
+    }
+
+    String[] parts = identifier.split(":");
+    if (parts.length < 2) {
+      logger.error("Invalid identifier format: {}", identifier);
+      throw new UsernameNotFoundException("Invalid identifier format");
+    }
+
+    UserRole type = UserRole.valueOf(parts[0].toUpperCase());
+    String loginId = parts[1];
+
+    return switch (type) {
+      case ROLE_USER -> userRepository.findByLoginId(loginId)
+          .map(CommonUserDetails::fromUser)
+          .orElseGet(() -> {
+            logger.error("User not found for ID: {}", loginId);
+            throw new UsernameNotFoundException("User not found for ID: " + loginId);
+          });
+
+      case ROLE_PARTNER -> null; // TODO: 파트너 로직 추가
+
+      case ROLE_RIDER -> null; // TODO: 라이더 로직 추가
+    };
+
+  }
+}

--- a/src/main/java/jyang/deliverydotdot/service/LocationService.java
+++ b/src/main/java/jyang/deliverydotdot/service/LocationService.java
@@ -9,11 +9,10 @@ import java.nio.charset.StandardCharsets;
 import jyang.deliverydotdot.dto.location.KakaoGeoResponse;
 import jyang.deliverydotdot.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -27,9 +26,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class LocationService {
-
-  private static final Logger logger = LoggerFactory.getLogger(LocationService.class);
 
   private final RestTemplate restTemplate;
 
@@ -63,16 +61,16 @@ public class LocationService {
             new Coordinate(Double.parseDouble(document.getX()),
                 Double.parseDouble(document.getY())));
       } else {
-        logger.error("No coordinates found for address: {}", address);
+        log.error("No coordinates found for address: {}", address);
         throw new RestApiException(NO_COORDINATES_FOUND_FOR_ADDRESS);
       }
     } catch (HttpClientErrorException ex) {
-      logger.error(
+      log.error(
           "HttpClientErrorException occurred while fetching coordinates for address: {}, Status code: {}, Response body: {}",
           address, ex.getStatusCode(), ex.getResponseBodyAsString(), ex);
       throw new RestApiException(INVALID_REQUEST);
     } catch (RestClientException ex) {
-      logger.error("RestClientException occurred while fetching coordinates for address: {}",
+      log.error("RestClientException occurred while fetching coordinates for address: {}",
           address, ex);
       throw new RestApiException(EXTERNAL_API_ERROR);
     }

--- a/src/main/java/jyang/deliverydotdot/service/LocationService.java
+++ b/src/main/java/jyang/deliverydotdot/service/LocationService.java
@@ -1,0 +1,80 @@
+package jyang.deliverydotdot.service;
+
+import static jyang.deliverydotdot.type.ErrorCode.EXTERNAL_API_ERROR;
+import static jyang.deliverydotdot.type.ErrorCode.INVALID_REQUEST;
+import static jyang.deliverydotdot.type.ErrorCode.NO_COORDINATES_FOUND_FOR_ADDRESS;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import jyang.deliverydotdot.dto.location.KakaoGeoResponse;
+import jyang.deliverydotdot.exception.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
+public class LocationService {
+
+  private static final Logger logger = LoggerFactory.getLogger(LocationService.class);
+
+  private final RestTemplate restTemplate;
+
+  private final GeometryFactory geometryFactory;
+
+  @Value("${kakao.api.key}")
+  private String apiKey;
+
+  public Point getCoordinatesFromAddress(String address) {
+    URI uri = UriComponentsBuilder
+        .fromHttpUrl("https://dapi.kakao.com/v2/local/search/address.json")
+        .queryParam("query", address)
+        .queryParam("analyze_type", "exact")
+        .encode(StandardCharsets.UTF_8)
+        .build()
+        .toUri();
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", "KakaoAK " + apiKey);
+    HttpEntity<String> entity = new HttpEntity<>(headers);
+
+    try {
+      ResponseEntity<KakaoGeoResponse> response = restTemplate.exchange(uri, HttpMethod.GET, entity,
+          KakaoGeoResponse.class);
+
+      if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null
+          && !response.getBody().getDocuments().isEmpty()) {
+        KakaoGeoResponse.Document document = response.getBody().getDocuments().get(0);
+        // 좌표 생성 및 반환
+        return geometryFactory.createPoint(
+            new Coordinate(Double.parseDouble(document.getX()),
+                Double.parseDouble(document.getY())));
+      } else {
+        logger.error("No coordinates found for address: {}", address);
+        throw new RestApiException(NO_COORDINATES_FOUND_FOR_ADDRESS);
+      }
+    } catch (HttpClientErrorException ex) {
+      logger.error(
+          "HttpClientErrorException occurred while fetching coordinates for address: {}, Status code: {}, Response body: {}",
+          address, ex.getStatusCode(), ex.getResponseBodyAsString(), ex);
+      throw new RestApiException(INVALID_REQUEST);
+    } catch (RestClientException ex) {
+      logger.error("RestClientException occurred while fetching coordinates for address: {}",
+          address, ex);
+      throw new RestApiException(EXTERNAL_API_ERROR);
+    }
+  }
+}

--- a/src/main/java/jyang/deliverydotdot/service/UserService.java
+++ b/src/main/java/jyang/deliverydotdot/service/UserService.java
@@ -6,10 +6,13 @@ import static jyang.deliverydotdot.type.ErrorCode.ALREADY_REGISTERED_LOGIN_ID;
 import static jyang.deliverydotdot.type.ErrorCode.ALREADY_REGISTERED_PHONE;
 
 import jyang.deliverydotdot.domain.User;
+import jyang.deliverydotdot.domain.UserDeliveryAddress;
 import jyang.deliverydotdot.dto.UserJoinForm;
 import jyang.deliverydotdot.exception.RestApiException;
+import jyang.deliverydotdot.repository.UserDeliveryAddressRepository;
 import jyang.deliverydotdot.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Point;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +21,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserService {
+
+  private final LocationService locationService;
+
+  private final UserDeliveryAddressRepository userDeliveryAddressRepository;
 
   private final UserRepository userRepository;
 
@@ -40,6 +47,20 @@ public class UserService {
         .build();
 
     userRepository.save(savedUser);
+
+    Point coordinates = locationService.getCoordinatesFromAddress(userJoinForm.getAddress());
+
+    System.out.println(coordinates);
+
+    UserDeliveryAddress deliveryAddress = UserDeliveryAddress.builder()
+        .user(savedUser)
+        .addressName("default")
+        .address(userJoinForm.getAddress())
+        .coordinates(coordinates)
+        .isDefaultAddress(true)
+        .build();
+
+    userDeliveryAddressRepository.save(deliveryAddress);
   }
 
   private void validateRegisterUser(UserJoinForm userJoinForm) {

--- a/src/main/java/jyang/deliverydotdot/service/UserService.java
+++ b/src/main/java/jyang/deliverydotdot/service/UserService.java
@@ -5,7 +5,6 @@ import static jyang.deliverydotdot.type.ErrorCode.ALREADY_REGISTERED_EMAIL;
 import static jyang.deliverydotdot.type.ErrorCode.ALREADY_REGISTERED_LOGIN_ID;
 import static jyang.deliverydotdot.type.ErrorCode.ALREADY_REGISTERED_PHONE;
 
-import java.util.logging.Logger;
 import jyang.deliverydotdot.domain.User;
 import jyang.deliverydotdot.domain.UserDeliveryAddress;
 import jyang.deliverydotdot.dto.UserJoinForm;
@@ -13,12 +12,14 @@ import jyang.deliverydotdot.exception.RestApiException;
 import jyang.deliverydotdot.repository.UserDeliveryAddressRepository;
 import jyang.deliverydotdot.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Point;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserService {
@@ -30,9 +31,6 @@ public class UserService {
   private final UserRepository userRepository;
 
   private final BCryptPasswordEncoder passwordEncoder;
-
-  private final Logger logger = Logger.getLogger(UserService.class.getName());
-
 
   @Transactional
   public void registerUser(UserJoinForm userJoinForm) {
@@ -66,15 +64,15 @@ public class UserService {
 
   private void validateRegisterUser(UserJoinForm userJoinForm) {
     if (userRepository.existsByLoginId(userJoinForm.getLoginId())) {
-      logger.warning("Already registered loginId: " + userJoinForm.getLoginId());
+      log.warn("Already registered loginId: " + userJoinForm.getLoginId());
       throw new RestApiException(ALREADY_REGISTERED_LOGIN_ID);
     }
     if (userRepository.existsByEmail(userJoinForm.getEmail())) {
-      logger.warning("Already registered email: " + userJoinForm.getEmail());
+      log.warn("Already registered email: " + userJoinForm.getEmail());
       throw new RestApiException(ALREADY_REGISTERED_EMAIL);
     }
     if (userRepository.existsByLoginId(userJoinForm.getPhone())) {
-      logger.warning("Already registered phone: " + userJoinForm.getPhone());
+      log.warn("Already registered phone: " + userJoinForm.getPhone());
       throw new RestApiException(ALREADY_REGISTERED_PHONE);
     }
   }

--- a/src/main/java/jyang/deliverydotdot/service/UserService.java
+++ b/src/main/java/jyang/deliverydotdot/service/UserService.java
@@ -5,6 +5,7 @@ import static jyang.deliverydotdot.type.ErrorCode.ALREADY_REGISTERED_EMAIL;
 import static jyang.deliverydotdot.type.ErrorCode.ALREADY_REGISTERED_LOGIN_ID;
 import static jyang.deliverydotdot.type.ErrorCode.ALREADY_REGISTERED_PHONE;
 
+import java.util.logging.Logger;
 import jyang.deliverydotdot.domain.User;
 import jyang.deliverydotdot.domain.UserDeliveryAddress;
 import jyang.deliverydotdot.dto.UserJoinForm;
@@ -30,6 +31,8 @@ public class UserService {
 
   private final BCryptPasswordEncoder passwordEncoder;
 
+  private final Logger logger = Logger.getLogger(UserService.class.getName());
+
 
   @Transactional
   public void registerUser(UserJoinForm userJoinForm) {
@@ -50,8 +53,6 @@ public class UserService {
 
     Point coordinates = locationService.getCoordinatesFromAddress(userJoinForm.getAddress());
 
-    System.out.println(coordinates);
-
     UserDeliveryAddress deliveryAddress = UserDeliveryAddress.builder()
         .user(savedUser)
         .addressName("default")
@@ -65,12 +66,15 @@ public class UserService {
 
   private void validateRegisterUser(UserJoinForm userJoinForm) {
     if (userRepository.existsByLoginId(userJoinForm.getLoginId())) {
+      logger.warning("Already registered loginId: " + userJoinForm.getLoginId());
       throw new RestApiException(ALREADY_REGISTERED_LOGIN_ID);
     }
     if (userRepository.existsByEmail(userJoinForm.getEmail())) {
+      logger.warning("Already registered email: " + userJoinForm.getEmail());
       throw new RestApiException(ALREADY_REGISTERED_EMAIL);
     }
     if (userRepository.existsByLoginId(userJoinForm.getPhone())) {
+      logger.warning("Already registered phone: " + userJoinForm.getPhone());
       throw new RestApiException(ALREADY_REGISTERED_PHONE);
     }
   }

--- a/src/main/java/jyang/deliverydotdot/type/ErrorCode.java
+++ b/src/main/java/jyang/deliverydotdot/type/ErrorCode.java
@@ -11,7 +11,10 @@ public enum ErrorCode {
   ALREADY_REGISTERED_LOGIN_ID(HttpStatus.BAD_REQUEST, "이미 등록된 로그인 id 입니다."),
   ALREADY_REGISTERED_EMAIL(HttpStatus.BAD_REQUEST, "이미 등록된 이메일 입니다."),
   ALREADY_REGISTERED_PHONE(HttpStatus.BAD_REQUEST, "이미 등록된 휴대전화 번호 입니다."),
-  INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
+  INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+  NO_COORDINATES_FOUND_FOR_ADDRESS(HttpStatus.UNPROCESSABLE_ENTITY, "주소에 대한 좌표를 찾을 수 없습니다."),
+  EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "외부 API 서버 오류가 발생했습니다."),
+  UNPROCESSABLE_ENTITY(HttpStatus.UNPROCESSABLE_ENTITY, "처리할 수 없는 요청입니다.");
   private final HttpStatus httpStatus;
   private final String description;
 }

--- a/src/main/java/jyang/deliverydotdot/type/UserRole.java
+++ b/src/main/java/jyang/deliverydotdot/type/UserRole.java
@@ -1,0 +1,12 @@
+package jyang.deliverydotdot.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserRole {
+
+  ROLE_USER, ROLE_PARTNER, ROLE_RIDER
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,7 @@ spring:
         use_sql_comments: true
         jdbc:
           time_zone: UTC
+    database-platform: org.hibernate.spatial.dialect.mysql.MySQL56InnoDBSpatialDialect
 
 logging:
   config: classpath:logback-spring.xml
@@ -25,3 +26,7 @@ logging:
 #      hibernate:
 #        SQL: DEBUG
 #        type: TRACE
+
+kakao:
+  api:
+    key: 4c3a33797d731925ec82252b4823a084

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,10 @@ spring:
           time_zone: UTC
     database-platform: org.hibernate.spatial.dialect.mysql.MySQL56InnoDBSpatialDialect
 
+  jwt:
+    secret: anlhbmdqcGFya2RpZHdvd25zcWtyd25nbWxmbHpodHBzeG1mamZxbGZlbGR0amRuZmNoc3VzdG9kamYxOTAyZmo4NGpmc2RmajA5anZ4a2NsdmJubjI0NSxtLjIzbjQ1OTh1Yjg5eGN2dWI4amtvbDI0M241bSx2OThzZDhmMAo=
+    expiration: 3600000
+
 logging:
   config: classpath:logback-spring.xml
 #  level:

--- a/src/test/java/jyang/deliverydotdot/controller/UserControllerTest.java
+++ b/src/test/java/jyang/deliverydotdot/controller/UserControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jyang.deliverydotdot.authentication.JwtTokenProvider;
 import jyang.deliverydotdot.config.SecurityConfig;
 import jyang.deliverydotdot.dto.UserJoinForm;
 import jyang.deliverydotdot.exception.RestApiException;
@@ -24,10 +25,10 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = CommonController.class, includeFilters = {
+@WebMvcTest(controllers = UserController.class, includeFilters = {
     @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
 })
-class CommonControllerTest {
+class UserControllerTest {
 
   @Autowired
   private MockMvc mockMvc;
@@ -37,6 +38,11 @@ class CommonControllerTest {
 
   @MockBean
   private UserService userService;
+
+  @MockBean
+  private JwtTokenProvider jwtTokenProvider;
+
+  private static final String USER_API_URL = "/api/v1/users/";
 
   @BeforeEach
   public void setup() {
@@ -59,7 +65,7 @@ class CommonControllerTest {
 
     //when
     //then
-    mockMvc.perform(post("/api/v1/common/users/join")
+    mockMvc.perform(post(USER_API_URL + "auth/join")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(user)))
         .andExpect(status().isCreated())
@@ -83,7 +89,7 @@ class CommonControllerTest {
 
     //when
     //then
-    mockMvc.perform(post("/api/v1/common/users/join")
+    mockMvc.perform(post(USER_API_URL + "auth/join")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(user)))
         .andExpect(status().isBadRequest())
@@ -109,7 +115,7 @@ class CommonControllerTest {
 
     //when
     //then
-    mockMvc.perform(post("/api/v1/common/users/join")
+    mockMvc.perform(post(USER_API_URL + "auth/join")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(user)))
         .andExpect(status().isBadRequest())
@@ -135,7 +141,7 @@ class CommonControllerTest {
 
     //when
     //then
-    mockMvc.perform(post("/api/v1/common/users/join")
+    mockMvc.perform(post(USER_API_URL + "auth/join")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(user)))
         .andExpect(status().isBadRequest())
@@ -160,7 +166,7 @@ class CommonControllerTest {
 
     //when
     //then
-    mockMvc.perform(post("/api/v1/common/users/join")
+    mockMvc.perform(post(USER_API_URL + "auth/join")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(user)))
         .andExpect(status().isBadRequest())
@@ -186,7 +192,7 @@ class CommonControllerTest {
 
     //when
     //then
-    mockMvc.perform(post("/api/v1/common/users/join")
+    mockMvc.perform(post(USER_API_URL + "auth/join")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(user)))
         .andExpect(status().isBadRequest())
@@ -211,7 +217,7 @@ class CommonControllerTest {
 
     //when
     //then
-    mockMvc.perform(post("/api/v1/common/users/join")
+    mockMvc.perform(post(USER_API_URL + "auth/join")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(user)))
         .andExpect(status().isBadRequest())
@@ -237,7 +243,7 @@ class CommonControllerTest {
 
     //when
     //then
-    mockMvc.perform(post("/api/v1/common/users/join")
+    mockMvc.perform(post(USER_API_URL + "auth/join")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(user)))
         .andExpect(status().isBadRequest())
@@ -257,7 +263,7 @@ class CommonControllerTest {
 
     //when
     //then
-    mockMvc.perform(post("/api/v1/common/users/join")
+    mockMvc.perform(post(USER_API_URL + "auth/join")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(user)))
         .andExpect(status().isBadRequest())
@@ -292,7 +298,7 @@ class CommonControllerTest {
 
     //when
     //then
-    mockMvc.perform(post("/api/v1/common/users/join")
+    mockMvc.perform(post(USER_API_URL + "auth/join")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(user)))
         .andExpect(status().isUnprocessableEntity())

--- a/src/test/java/jyang/deliverydotdot/security/SecurityTest.java
+++ b/src/test/java/jyang/deliverydotdot/security/SecurityTest.java
@@ -1,0 +1,58 @@
+package jyang.deliverydotdot.security;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jyang.deliverydotdot.authentication.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class SecurityTest {
+
+  @Autowired
+  private JwtTokenProvider jwtTokenProvider;
+
+  @Value("${spring.jwt.secret}")
+  private String secretKey;
+
+  @Value("${spring.jwt.expiration}")
+  private long expiration;
+
+  @BeforeEach
+  void setUp() {
+    jwtTokenProvider = new JwtTokenProvider(secretKey, expiration);
+  }
+
+  @Test
+  void 토큰생성() {
+    String username = "user";
+    String role = "ROLE_USER";
+    String token = jwtTokenProvider.createToken(username, role);
+
+    assertNotNull(token);
+    assertEquals(jwtTokenProvider.getUsername(token), username);
+    assertEquals(jwtTokenProvider.getRole(token), role);
+  }
+
+  @Test
+  void 토큰만료확인() {
+    String username = "user";
+    String role = "ROLE_USER";
+    String token = jwtTokenProvider.createToken(username, role);
+
+    assertNotNull(token);
+    assertEquals(jwtTokenProvider.getUsername(token), username);
+    assertEquals(jwtTokenProvider.getRole(token), role);
+    assertEquals(jwtTokenProvider.isExpired(token), false);
+  }
+  
+}

--- a/src/test/java/jyang/deliverydotdot/service/LocationServiceTest.java
+++ b/src/test/java/jyang/deliverydotdot/service/LocationServiceTest.java
@@ -1,0 +1,107 @@
+package jyang.deliverydotdot.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import jyang.deliverydotdot.dto.location.KakaoGeoResponse;
+import jyang.deliverydotdot.exception.RestApiException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Point;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriUtils;
+
+@ExtendWith(MockitoExtension.class)
+class LocationServiceTest {
+
+  @Mock
+  private RestTemplate restTemplate;
+
+  @InjectMocks
+  private LocationService locationService;
+
+  @Test
+  void 주소로좌표가져오기_성공() {
+    // given
+    String address = "valid address";
+    String url =
+        "https://dapi.kakao.com/v2/local/search/address.json?query=" + UriUtils.encode(address,
+            StandardCharsets.UTF_8);
+    KakaoGeoResponse mockResponse = new KakaoGeoResponse();
+    mockResponse.setDocuments(
+        List.of(new KakaoGeoResponse.Document("valid address", "37.5665", "126.9780")));
+
+    // when
+    when(restTemplate.exchange(eq(url), eq(HttpMethod.GET), any(), eq(KakaoGeoResponse.class)))
+        .thenReturn(new ResponseEntity<>(mockResponse, HttpStatus.OK));
+
+    Point result = locationService.getCoordinatesFromAddress(address);
+
+    // then
+    assertNotNull(result);
+    assertEquals(37.5665, result.getX());
+    assertEquals(126.9780, result.getY());
+  }
+
+  @Test
+  void 주소로좌표가져오기_실패_주소에대한좌표찾을수없음() {
+    // given
+    String address = "invalid address";
+    String url =
+        "https://dapi.kakao.com/v2/local/search/address.json?query=" + UriUtils.encode(address,
+            StandardCharsets.UTF_8);
+
+    KakaoGeoResponse emptyResponse = new KakaoGeoResponse();
+    emptyResponse.setDocuments(Collections.emptyList());
+
+    // when
+    when(restTemplate.exchange(eq(url), eq(HttpMethod.GET), any(), eq(KakaoGeoResponse.class)))
+        .thenReturn(ResponseEntity.ok(emptyResponse));
+
+    // then
+    assertThrows(RestApiException.class, () -> locationService.getCoordinatesFromAddress(address));
+  }
+
+  @Test
+  void 주소로좌표가져오기_실패_클라이언트에러() {
+    // Arrange
+    String address = "some address";
+    String url =
+        "https://dapi.kakao.com/v2/local/search/address.json?query=" + UriUtils.encode(address,
+            StandardCharsets.UTF_8);
+    when(restTemplate.exchange(eq(url), eq(HttpMethod.GET), any(), eq(KakaoGeoResponse.class)))
+        .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+
+    // then
+    assertThrows(RestApiException.class, () -> locationService.getCoordinatesFromAddress(address));
+  }
+
+  @Test
+  void 주소로좌표가져오기_실패_서버에러() {
+    // Arrange
+    String address = "some address";
+    String url =
+        "https://dapi.kakao.com/v2/local/search/address.json?query=" + UriUtils.encode(address,
+            StandardCharsets.UTF_8);
+    when(restTemplate.exchange(eq(url), eq(HttpMethod.GET), any(), eq(KakaoGeoResponse.class)))
+        .thenThrow(new RestClientException("Service Unavailable"));
+
+    // then
+    assertThrows(RestApiException.class, () -> locationService.getCoordinatesFromAddress(address));
+  }
+}

--- a/src/test/java/jyang/deliverydotdot/service/UserServiceTest.java
+++ b/src/test/java/jyang/deliverydotdot/service/UserServiceTest.java
@@ -3,6 +3,8 @@ package jyang.deliverydotdot.service;
 import static jyang.deliverydotdot.type.ErrorCode.ALREADY_REGISTERED_EMAIL;
 import static jyang.deliverydotdot.type.ErrorCode.ALREADY_REGISTERED_LOGIN_ID;
 import static jyang.deliverydotdot.type.ErrorCode.ALREADY_REGISTERED_PHONE;
+import static jyang.deliverydotdot.type.ErrorCode.INVALID_REQUEST;
+import static jyang.deliverydotdot.type.ErrorCode.NO_COORDINATES_FOUND_FOR_ADDRESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
@@ -12,45 +14,49 @@ import static org.mockito.Mockito.when;
 import jyang.deliverydotdot.domain.User;
 import jyang.deliverydotdot.dto.UserJoinForm;
 import jyang.deliverydotdot.exception.RestApiException;
+import jyang.deliverydotdot.repository.UserDeliveryAddressRepository;
 import jyang.deliverydotdot.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest
 public class UserServiceTest {
 
-  @Autowired
-  private UserService userService;
-
-  @MockBean
+  @Mock
   private UserRepository userRepository;
-
-  @MockBean
+  @Mock
+  private UserDeliveryAddressRepository userDeliveryAddressRepository;
+  @Mock
   private BCryptPasswordEncoder passwordEncoder;
+  @Mock
+  private LocationService locationService;
+
+  @InjectMocks
+  private UserService userService;
 
   private UserJoinForm validUserJoinForm;
 
   @BeforeEach
   void setUp() {
     validUserJoinForm = new UserJoinForm("userLoginId", "userPassword", "userName",
-        "user@example.com", "010-1234-5678", "user address");
+        "user@example.com", "010-1234-5678", "user location");
     when(passwordEncoder.encode("userPassword")).thenReturn("encodedPassword");
     when(userRepository.existsByLoginId("userLoginId")).thenReturn(false);
     when(userRepository.existsByEmail("user@example.com")).thenReturn(false);
     when(userRepository.existsByLoginId("010-1234-5678")).thenReturn(false);
+    when(locationService.getCoordinatesFromAddress("user location")).thenReturn(null);
   }
 
   @Test
   void 유저생성_성공() {
     userService.registerUser(validUserJoinForm);
     verify(userRepository).save(any(User.class));
+    verify(locationService).getCoordinatesFromAddress("user location");
   }
 
   @Test
@@ -73,10 +79,30 @@ public class UserServiceTest {
 
   @Test
   void 유저생성_실패_이미등록된휴대전화() {
-    when(userRepository.existsByLoginId("010-1234-5678")).thenReturn(true);
+    when(userRepository.existsByPhone("010-1234-5678")).thenReturn(true);
     RestApiException exception = assertThrows(RestApiException.class,
         () -> userService.registerUser(validUserJoinForm));
 
     assertEquals(ALREADY_REGISTERED_PHONE, exception.getErrorCode());
+  }
+
+  @Test
+  void 유저생성_실패_좌표없음() {
+    when(locationService.getCoordinatesFromAddress("user location")).thenThrow(
+        new RestApiException(NO_COORDINATES_FOUND_FOR_ADDRESS));
+    RestApiException exception = assertThrows(RestApiException.class,
+        () -> userService.registerUser(validUserJoinForm));
+
+    assertEquals(NO_COORDINATES_FOUND_FOR_ADDRESS, exception.getErrorCode());
+  }
+
+  @Test
+  void 유저생성_실패_위치정보예외() {
+    when(locationService.getCoordinatesFromAddress("user location")).thenThrow(
+        new RestApiException(INVALID_REQUEST));
+    RestApiException exception = assertThrows(RestApiException.class,
+        () -> userService.registerUser(validUserJoinForm));
+
+    assertEquals(INVALID_REQUEST, exception.getErrorCode());
   }
 }


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 회원 가입시 주소를 회원 엔티티에만 저장하도록 되어있었음
- 로그인 기능 미구현 

**TO-BE**
- 회원 가입시 입력하는 주소로 기본 배송지를 추가하도록 기능 추가
- 입력한 주소를 카카오 local api를 이용하여 좌표로 변환하여 저장
- 고객, 점주, 라이더에 대해 각각 다른 로그인 필터를 적용하기 위해 보안 설정을 분리. 일부 컨트롤러 설계도 변경
- 로그인 성공 시 JWT 발급 기능 추가. 인증 여부 테스트를 위한 컨트롤러 추가

### 테스트

- [x] 테스트 코드
- [x] API 테스트 

#3 
